### PR TITLE
[haxe] shave off some code (cast)

### DIFF
--- a/src/haxe/Main.hx
+++ b/src/haxe/Main.hx
@@ -30,8 +30,8 @@ class Main
 				var bytes = new Uint8Array(buf, 4);			
 				var sp = new ScreenPressor(X, Y);
 				var dst = new Int32Array(X * Y);
-				var inp : InputElement = cast(Browser.document.getElementById("N"), InputElement);
-				var N = Std.parseInt( inp.value );				
+				var inp : InputElement = cast Browser.document.getElementById("N");
+				var N = Std.parseInt( inp.value );
 				if (N < 0 || N > 1000) {
 					txt.innerHTML = "You must be joking!"; return;
 				}


### PR DESCRIPTION
Hi @damoebius, and thanks for updating the benchmark.

The aim of this PR is to just try to shave off a couple of kb from the haxe-js output, by avoiding the `InputElement` safe cast.

I've tinkered a bit further with the code and noticed that there's another thing that could be done to reduce the haxe-js size without influencing the perf much (at least on my laptop).
Probably you've already tried it (sorry if that's the case), but my idea was "not inlining" at least one of the title cased `Decode*` functions ("not inlining" both of them might be helpful for sys targets). 

In my little experiment that would bring the (js) size down to around 16kb.

And when haxe will drop the typedarray compat/polyfill (happening soon-ish much probably) the output will be even smaller.
